### PR TITLE
ISYGarageDoorAccessory error fixes

### DIFF
--- a/src/ISYGarageDoorAccessory.ts
+++ b/src/ISYGarageDoorAccessory.ts
@@ -10,7 +10,7 @@ export class ISYGarageDoorAccessory extends ISYAccessory<InsteonRelayDevice, Cat
 	public alternate: any;
 	public targetGarageState: any;
 	public currentGarageState: any;
-	public garageDoorService: any;
+	public primaryService: any;
 
 	constructor(sensorDevice, relayDevice, name, timeToOpen, alternate, platform) {
 		super(sensorDevice, platform);
@@ -18,11 +18,11 @@ export class ISYGarageDoorAccessory extends ISYAccessory<InsteonRelayDevice, Cat
 		this.relayDevice = relayDevice;
 		this.alternate = alternate === undefined ? false : alternate;
 		if (this.getSensorState()) {
-			this.log.info(`GARAGE: ${this.name} Initial set during startup the sensor is open so defaulting states to open`);
+			this.logger.info(`GARAGE: ${this.name} Initial set during startup the sensor is open so defaulting states to open`);
 			this.targetGarageState = Characteristic.TargetDoorState.OPEN;
 			this.currentGarageState = Characteristic.CurrentDoorState.OPEN;
 		} else {
-			this.log.info(`GARAGE: ${this.name} Initial set during startup the sensor is closed so defaulting states to closed`);
+			this.logger.info(`GARAGE: ${this.name} Initial set during startup the sensor is closed so defaulting states to closed`);
 			this.targetGarageState = Characteristic.TargetDoorState.CLOSED;
 			this.currentGarageState = Characteristic.CurrentDoorState.CLOSED;
 		}
@@ -53,7 +53,7 @@ export class ISYGarageDoorAccessory extends ISYAccessory<InsteonRelayDevice, Cat
 		if (this.currentGarageState === Characteristic.CurrentDoorState.OPEN) {
 			if (targetState === Characteristic.TargetDoorState.CLOSED) {
 				this.logger.info(`GARAGE: Current state is open and target is closed. Changing state to closing and sending command`);
-				this.garageDoorService.setCharacteristic(Characteristic.CurrentDoorState, Characteristic.CurrentDoorState.CLOSING);
+				this.primaryService.setCharacteristic(Characteristic.CurrentDoorState, Characteristic.CurrentDoorState.CLOSING);
 				this.sendGarageDoorCommand(callback);
 			}
 		} else if (this.currentGarageState === Characteristic.CurrentDoorState.CLOSED) {
@@ -65,14 +65,14 @@ export class ISYGarageDoorAccessory extends ISYAccessory<InsteonRelayDevice, Cat
 		} else if (this.currentGarageState === Characteristic.CurrentDoorState.OPENING) {
 			if (targetState === Characteristic.TargetDoorState.CLOSED) {
 				this.logger.info(`GARAGE: ${this.device.name} Current state is opening and target is closed. Sending command and changing state to closing`);
-				this.garageDoorService.setCharacteristic(Characteristic.CurrentDoorState, Characteristic.CurrentDoorState.CLOSING);
+				this.primaryService.setCharacteristic(Characteristic.CurrentDoorState, Characteristic.CurrentDoorState.CLOSING);
 				this.sendGarageDoorCommand(() => setTimeout(() => that.sendGarageDoorCommand(callback), 3000));
 				return;
 			}
 		} else if (this.currentGarageState === Characteristic.CurrentDoorState.CLOSING) {
 			if (targetState === Characteristic.TargetDoorState.OPEN) {
 				this.logger.info(`GARAGE: ${this.device.name} Current state is closing and target is open. Sending command and setting timeout to complete`);
-				this.garageDoorService.setCharacteristic(Characteristic.CurrentDoorState, Characteristic.CurrentDoorState.OPENING);
+				this.primaryService.setCharacteristic(Characteristic.CurrentDoorState, Characteristic.CurrentDoorState.OPENING);
 				this.sendGarageDoorCommand(() => {
 					that.sendGarageDoorCommand(callback);
 					setTimeout(that.completeOpen.bind(that), that.timeToOpen);
@@ -95,7 +95,7 @@ export class ISYGarageDoorAccessory extends ISYAccessory<InsteonRelayDevice, Cat
 	public completeOpen() {
 		if (this.currentGarageState === Characteristic.CurrentDoorState.OPENING) {
 			this.logger.info('Current door has bee opening long enough, marking open');
-			this.garageDoorService.setCharacteristic(Characteristic.CurrentDoorState, Characteristic.CurrentDoorState.OPEN);
+			this.primaryService.setCharacteristic(Characteristic.CurrentDoorState, Characteristic.CurrentDoorState.OPEN);
 		} else {
 			this.logger.info('Opening aborted so not setting opened state automatically');
 		}
@@ -108,9 +108,9 @@ export class ISYGarageDoorAccessory extends ISYAccessory<InsteonRelayDevice, Cat
 				this.logger.info(`GARAGE:  ${this.device.name}Current state of door is open and now sensor matches. No action to take`);
 			} else if (this.currentGarageState === Characteristic.CurrentDoorState.CLOSED) {
 				this.logger.info(`GARAGE:  ${this.device.name}Current state of door is closed and now sensor says open. Setting state to opening`);
-				this.garageDoorService.setCharacteristic(Characteristic.CurrentDoorState, Characteristic.CurrentDoorState.OPENING);
+				this.primaryService.setCharacteristic(Characteristic.CurrentDoorState, Characteristic.CurrentDoorState.OPENING);
 				this.targetGarageState = Characteristic.TargetDoorState.OPEN;
-				this.garageDoorService.setCharacteristic(Characteristic.TargetDoorState, Characteristic.CurrentDoorState.OPEN);
+				this.primaryService.setCharacteristic(Characteristic.TargetDoorState, Characteristic.CurrentDoorState.OPEN);
 				setTimeout(this.completeOpen.bind(this), this.timeToOpen);
 			} else if (this.currentGarageState === Characteristic.CurrentDoorState.OPENING) {
 				this.logger.info(`GARAGE:  ${this.device.name}Current state of door is opening and now sensor matches. No action to take`);
@@ -120,21 +120,21 @@ export class ISYGarageDoorAccessory extends ISYAccessory<InsteonRelayDevice, Cat
 		} else {
 			if (this.currentGarageState === Characteristic.CurrentDoorState.OPEN) {
 				this.logger.info(`GARAGE:  ${this.device.name}Current state of door is open and now sensor shows closed. Setting current state to closed`);
-				this.garageDoorService.setCharacteristic(Characteristic.CurrentDoorState, Characteristic.CurrentDoorState.CLOSED);
+				this.primaryService.setCharacteristic(Characteristic.CurrentDoorState, Characteristic.CurrentDoorState.CLOSED);
 				this.targetGarageState = Characteristic.TargetDoorState.CLOSED;
-				this.garageDoorService.setCharacteristic(Characteristic.TargetDoorState, Characteristic.TargetDoorState.CLOSED);
+				this.primaryService.setCharacteristic(Characteristic.TargetDoorState, Characteristic.TargetDoorState.CLOSED);
 			} else if (this.currentGarageState === Characteristic.CurrentDoorState.CLOSED) {
 				this.logger.info(`GARAGE:  ${this.device.name}Current state of door is closed and now sensor shows closed. No action to take`);
 			} else if (this.currentGarageState === Characteristic.CurrentDoorState.OPENING) {
 				this.logger.info(`GARAGE:  ${this.device.name} Current state of door is opening and now sensor shows closed. Setting current state to closed`);
-				this.garageDoorService.setCharacteristic(Characteristic.CurrentDoorState, Characteristic.CurrentDoorState.CLOSED);
+				this.primaryService.setCharacteristic(Characteristic.CurrentDoorState, Characteristic.CurrentDoorState.CLOSED);
 				this.targetGarageState = Characteristic.TargetDoorState.CLOSED;
-				this.garageDoorService.setCharacteristic(Characteristic.TargetDoorState, Characteristic.TargetDoorState.CLOSED);
+				this.primaryService.setCharacteristic(Characteristic.TargetDoorState, Characteristic.TargetDoorState.CLOSED);
 			} else if (this.currentGarageState === Characteristic.CurrentDoorState.CLOSING) {
 				this.logger.info(`GARAGE:  ${this.device.name}Current state of door is closing and now sensor shows closed. Setting current state to closed`);
-				this.garageDoorService.setCharacteristic(Characteristic.CurrentDoorState, Characteristic.CurrentDoorState.CLOSED);
+				this.primaryService.setCharacteristic(Characteristic.CurrentDoorState, Characteristic.CurrentDoorState.CLOSED);
 				this.targetGarageState = Characteristic.TargetDoorState.CLOSED;
-				this.garageDoorService.setCharacteristic(Characteristic.TargetDoorState, Characteristic.TargetDoorState.CLOSED);
+				this.primaryService.setCharacteristic(Characteristic.TargetDoorState, Characteristic.TargetDoorState.CLOSED);
 			}
 		}
 	}
@@ -144,13 +144,13 @@ export class ISYGarageDoorAccessory extends ISYAccessory<InsteonRelayDevice, Cat
 	// Returns the set of services supported by this object.
 	public setupServices() {
 		super.setupServices();
-		const garageDoorService = this.platformAccessory.getOrAddService(Service.GarageDoorOpener);
-		this.garageDoorService = garageDoorService;
-		garageDoorService.getCharacteristic(Characteristic.TargetDoorState).on(CharacteristicEventTypes.SET, this.setTargetDoorState.bind(this));
-		garageDoorService.getCharacteristic(Characteristic.TargetDoorState).on(CharacteristicEventTypes.GET, this.getTargetDoorState.bind(this));
-		garageDoorService.getCharacteristic(Characteristic.CurrentDoorState).on(CharacteristicEventTypes.GET, this.getCurrentDoorState.bind(this));
-		garageDoorService.getCharacteristic(Characteristic.CurrentDoorState).on(CharacteristicEventTypes.SET, this.setCurrentDoorState.bind(this));
-		garageDoorService.getCharacteristic(Characteristic.ObstructionDetected).on(CharacteristicEventTypes.GET, this.getObstructionState.bind(this));
+		const primaryService = this.platformAccessory.getOrAddService(Service.GarageDoorOpener);
+		this.primaryService = primaryService;
+		primaryService.getCharacteristic(Characteristic.TargetDoorState).on(CharacteristicEventTypes.SET, this.setTargetDoorState.bind(this));
+		primaryService.getCharacteristic(Characteristic.TargetDoorState).on(CharacteristicEventTypes.GET, this.getTargetDoorState.bind(this));
+		primaryService.getCharacteristic(Characteristic.CurrentDoorState).on(CharacteristicEventTypes.GET, this.getCurrentDoorState.bind(this));
+		primaryService.getCharacteristic(Characteristic.CurrentDoorState).on(CharacteristicEventTypes.SET, this.setCurrentDoorState.bind(this));
+		primaryService.getCharacteristic(Characteristic.ObstructionDetected).on(CharacteristicEventTypes.GET, this.getObstructionState.bind(this));
 
 	}
 }


### PR DESCRIPTION
Ran into a couple issues when trying to setup a garage door.

First is `this.log` was throwing the following error:

```
(node:68922) UnhandledPromiseRejectionWarning: TypeError: Cannot read property 'info' of undefined
    at new ISYGarageDoorAccessory (/usr/local/lib/node_modules/homebridge-isy/src/ISYGarageDoorAccessory.ts:25:13)
    at /usr/local/lib/node_modules/homebridge-isy/src/ISYPlatform.ts:280:7
    at runMicrotasks (<anonymous>)
    at processTicksAndRejections (internal/process/task_queues.js:97:5)
    at ISYPlatform.createAccessories (/usr/local/lib/node_modules/homebridge-isy/src/ISYPlatform.ts:236:3)
    at HomebridgeAPI.<anonymous> (/usr/local/lib/node_modules/homebridge-isy/src/ISYPlatform.ts:69:4)
(node:68922) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). To terminate the node process on unhandled promise rejection, use the CLI flag `--unhandled-rejections=strict` (see https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode). (rejection id: 1)
(node:68922) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
```

Changing this to `logger` like the rest resolves it,  but then exposes:

```
(node:69082) UnhandledPromiseRejectionWarning: TypeError: Cannot set property 'isPrimaryService' of undefined
    at ISYGarageDoorAccessory.configure (/usr/local/lib/node_modules/homebridge-isy/src/ISYAccessory.ts:77:3)
    at /usr/local/lib/node_modules/homebridge-isy/src/ISYPlatform.ts:328:11
    at processTicksAndRejections (internal/process/task_queues.js:97:5)
    at ISYPlatform.createAccessories (/usr/local/lib/node_modules/homebridge-isy/src/ISYPlatform.ts:236:3)
    at HomebridgeAPI.<anonymous> (/usr/local/lib/node_modules/homebridge-isy/src/ISYPlatform.ts:69:4)
(node:69082) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). To terminate the node process on unhandled promise rejection, use the CLI flag `--unhandled-rejections=strict` (see https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode). (rejection id: 1)
(node:69082) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
```

This is because `ISYAccessory` is assuming the service is called `platformAccessory` but `ISYGarageDoorAccessory` still uses the old `garageDoorService` property.

Changing those two things allowed me to get the Garage door to show up in HomeKit.
